### PR TITLE
docs: document the branch/PR workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,9 @@ readable, and well-tested rather than feature-complete.
 - Errors from the query engine wrap `query.ErrNotFound` where appropriate; keep
   that contract.
 - Run `gofmt -w .` before committing.
+- `main` is protected: never commit to it directly. Work on a
+  `<type>/<name>` branch, push, open a PR, squash-merge once CI is green.
+  See [CONTRIBUTING.md](CONTRIBUTING.md#branching--pull-requests).
 
 ## Definition of done
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,23 @@ make fuzz       # short fuzz run over the path parser + resolver
 
 `go` 1.25+ is required. There is no other toolchain dependency.
 
+## Branching & pull requests
+
+`main` is protected — all changes land through a pull request that passes CI.
+
+```sh
+git checkout main && git pull            # start from the latest main
+git checkout -b <type>/<short-name>      # e.g. fix/wildcard-index, docs/branching
+# ...work, committing in logical steps...
+git push -u origin <type>/<short-name>
+# open the PR from the URL git prints; let CI finish; then "Squash and merge"
+git checkout main && git pull            # sync; the branch is auto-deleted on merge
+```
+
+Branch name prefixes: `feat/`, `fix/`, `docs/`, `test/`, `ci/`, `refactor/`,
+`chore/`. Keep a branch scoped to one change. Rebase on `main` (or use the PR's
+"Update branch" button) if it falls behind.
+
 ## Before opening a pull request
 
 - `make lint` and `make test` pass.


### PR DESCRIPTION
main is protected now — add a "Branching & pull requests" section to CONTRIBUTING.md and a pointer in CLAUDE.md.

<!-- Keep it short. Delete sections that don't apply. -->

## What & why

## Checklist

- [ ] `make lint` and `make test` pass
- [ ] New behaviour has a test (CLI behaviour has a `cmd` test)
- [ ] `gofmt -w .` run; `go mod tidy` is clean
- [ ] Golden files regenerated if output changed on purpose
- [ ] `CHANGELOG.md` `[Unreleased]` updated
