### PR TITLE
ci: let Scorecard use a read-only PAT for token-gated checks

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -23,6 +23,10 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
+          # Optional fine-grained PAT (repo: Administration + Contents, read-only)
+          # so Scorecard can score the token-gated checks like Branch-Protection.
+          # Scorecard degrades gracefully if the secret is missing or expired.
+          repo_token: ${{ secrets.SCORECARD_TOKEN }}
           publish_results: true
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:


### PR DESCRIPTION
Adds repo_token so the Branch-Protection (and Webhooks) checks can be scored. Requires a SCORECARD_TOKEN secret: a fine-grained PAT scoped to this repo with Administration + Contents read-only. Absent/expired secret degrades gracefully.

<!-- Keep it short. Delete sections that don't apply. -->

## What & why

## Checklist

- [ ] `make lint` and `make test` pass
- [ ] New behaviour has a test (CLI behaviour has a `cmd` test)
- [ ] `gofmt -w .` run; `go mod tidy` is clean
- [ ] Golden files regenerated if output changed on purpose
- [ ] `CHANGELOG.md` `[Unreleased]` updated
