### PR TITLE
test: fuzz the set/delete writer; reject non-UTF-8 paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- `path.Parse` rejects a path expression that is not valid UTF-8 up front,
+  instead of failing later at the YAML encode step. Surfaced by fuzzing the
+  `set` / `delete` writer.
+
 ## [0.2.0] - 2026-09-01
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ readable, and well-tested rather than feature-complete.
 - `make cover` — coverage summary
 - `make lint` — golangci-lint, pinned (config in `.golangci.yml`)
 - `make vulncheck` — govulncheck
-- `make fuzz` — short fuzz run (path + query)
+- `make fuzz` — short fuzz run (path, query, ymledit)
 - `make run ARGS="'.a.b' testdata/compose.yml"`
 
 ## Layout
@@ -32,7 +32,7 @@ readable, and well-tested rather than feature-complete.
 - `internal/query/` — read-only resolver: `Run(doc any, expr) ([]any, error)`,
   wildcards fan out. Fuzzed.
 - `internal/ymledit/` — `Set` and `Delete` edit a `*yaml.Node` tree preserving
-  comments and key order; back `yaymlq set` / `yaymlq delete`.
+  comments and key order; back `yaymlq set` / `yaymlq delete`. Fuzzed.
 
 ## Conventions
 

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,10 @@ cover:
 
 FUZZTIME ?= 20s
 fuzz:
-	go test ./internal/path  -run '^$$' -fuzz FuzzParse -fuzztime $(FUZZTIME)
-	go test ./internal/query -run '^$$' -fuzz FuzzRun   -fuzztime $(FUZZTIME)
+	go test ./internal/path    -run '^$$' -fuzz FuzzParse  -fuzztime $(FUZZTIME)
+	go test ./internal/query   -run '^$$' -fuzz FuzzRun    -fuzztime $(FUZZTIME)
+	go test ./internal/ymledit -run '^$$' -fuzz FuzzSet    -fuzztime $(FUZZTIME)
+	go test ./internal/ymledit -run '^$$' -fuzz FuzzDelete -fuzztime $(FUZZTIME)
 
 GOLANGCI_VERSION ?= v2.1.6
 lint:

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ $ cat cfg.yaml | yaymlq rm .debug
 make test     # go test ./...
 make cover    # coverage summary
 make lint     # golangci-lint (pinned, via `go run` — no install needed)
-make fuzz     # short fuzz run over the path parser + resolver
+make fuzz     # short fuzz run over the path parser, resolver, and set/delete writer
 make all      # fmt + vet + test + build
 ```
 

--- a/internal/path/path.go
+++ b/internal/path/path.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 )
 
 // Segment is a single step in a parsed path: a map key, a slice index, or a
@@ -66,6 +67,9 @@ func Format(segs []Segment) string {
 // An empty path (or ".") returns no segments, which callers treat as "the whole
 // document".
 func Parse(expr string) ([]Segment, error) {
+	if !utf8.ValidString(expr) {
+		return nil, fmt.Errorf("path %q is not valid UTF-8", expr)
+	}
 	expr = strings.TrimSpace(expr)
 	expr = strings.TrimPrefix(expr, ".")
 	if expr == "" {

--- a/internal/path/path_test.go
+++ b/internal/path/path_test.go
@@ -39,7 +39,7 @@ func TestParse(t *testing.T) {
 }
 
 func TestParseErrors(t *testing.T) {
-	for _, expr := range []string{"a[", "a[x]", `"unterminated`, "a[1"} {
+	for _, expr := range []string{"a[", "a[x]", `"unterminated`, "a[1", "\xd9", "a.\xff.b"} {
 		if _, err := path.Parse(expr); err == nil {
 			t.Errorf("Parse(%q): expected error", expr)
 		}

--- a/internal/ymledit/fuzz_test.go
+++ b/internal/ymledit/fuzz_test.go
@@ -1,0 +1,94 @@
+package ymledit_test
+
+import (
+	"testing"
+
+	"github.com/reticule-poirot/yaymlq/internal/path"
+	"github.com/reticule-poirot/yaymlq/internal/ymledit"
+	"gopkg.in/yaml.v3"
+)
+
+const fuzzSeedDoc = `
+name: demo
+meta:
+  labels: {app: api, tier: backend}
+  ports: [80, 443, 8080]
+nested:
+  a: {b: {c: deep}}
+list:
+  - {id: 1, enabled: true}
+  - {id: 2, enabled: false}
+`
+
+// freshSeed returns a newly decoded copy of fuzzSeedDoc; Set and Delete mutate
+// the tree in place, so every fuzz iteration needs its own.
+func freshSeed(t *testing.T) *yaml.Node {
+	t.Helper()
+	var doc yaml.Node
+	if err := yaml.Unmarshal([]byte(fuzzSeedDoc), &doc); err != nil {
+		t.Fatalf("seed doc: %v", err)
+	}
+	return &doc
+}
+
+// FuzzSet checks that setting an arbitrary path/value into a real document never
+// panics, and that a successful edit leaves a tree that still re-encodes.
+func FuzzSet(f *testing.F) {
+	seeds := []struct{ expr, val string }{
+		{".name", "changed"},
+		{".meta.labels.app", "web"},
+		{".meta.ports[0]", "9090"},
+		{".meta.ports[-1]", "0"},
+		{".nested.a.b.c", "x"},
+		{".brand.new.key", "42"},
+		{".list[1].enabled", "true"},
+		{"", "x"},
+		{".meta.*", "x"},
+		{"a[", "x"},
+	}
+	for _, s := range seeds {
+		f.Add(s.expr, s.val)
+	}
+
+	f.Fuzz(func(t *testing.T, expr, val string) {
+		segs, err := path.Parse(expr)
+		if err != nil {
+			return
+		}
+		value, err := ymledit.ParseValue(val, false)
+		if err != nil {
+			return
+		}
+		doc := freshSeed(t)
+		if err := ymledit.Set(doc, segs, value); err != nil {
+			return
+		}
+		if _, err := yaml.Marshal(doc); err != nil {
+			t.Fatalf("Set(%q, %q) produced a tree that will not encode: %v", expr, val, err)
+		}
+	})
+}
+
+// FuzzDelete checks the same for removals.
+func FuzzDelete(f *testing.F) {
+	for _, expr := range []string{
+		".name", ".meta.labels.app", ".meta.ports[0]", ".meta.ports[-1]",
+		".nested.a.b", ".list[0]", ".missing", "", ".meta.*", "a[",
+	} {
+		f.Add(expr)
+	}
+
+	f.Fuzz(func(t *testing.T, expr string) {
+		segs, err := path.Parse(expr)
+		if err != nil {
+			return
+		}
+		doc := freshSeed(t)
+		if err := ymledit.Delete(doc, segs); err != nil {
+			return
+		}
+		if _, err := yaml.Marshal(doc); err != nil {
+			t.Fatalf("Delete(%q) produced a tree that will not encode: %v", expr, err)
+		}
+	})
+}


### PR DESCRIPTION
`ymledit` has two tree-mutators (`Set`, `Delete`) and neither was fuzzed —
only `path` and `query` were.

## Added

- **`FuzzSet`** / **`FuzzDelete`** (`internal/ymledit/fuzz_test.go`) — each
  iteration decodes a fresh copy of a seed document, applies the mutation along
  an arbitrary parsed path, and asserts the resulting tree still `yaml.Marshal`s.
- `make fuzz` and the CI `hygiene` job now run all four targets.

## Fixed (found by `FuzzSet`)

A path expression containing invalid UTF-8 (e.g. `"\xd9"`) was accepted by
`path.Parse`, inserted as a map key by `Set`, and only rejected downstream when
`yaml.Marshal` refused it. `path.Parse` now rejects non-UTF-8 input up front — a
YAML document is UTF-8 by spec, so such a segment could never match a key or be
written anyway. Added `TestParseErrors` cases.

## Checks

`make lint` (0 issues), `go test -race ./...`, `make fuzz FUZZTIME=15s` (all four
green), coverage 90.7%, `path.Parse` still 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)