### PR TITLE
test: lock in collection values for `set`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- `set <path> <value>` — `<value>` is now documented and tested to accept a YAML
+  collection (`set .labels '{team: infra}'`, `set .ports '[80, 443]'`), not only
+  a scalar. `-s/--string` still takes the argument verbatim.
 - `path.Parse` rejects a path expression that is not valid UTF-8 up front,
   instead of failing later at the YAML encode step. Surfaced by fuzzing the
   `set` / `delete` writer.

--- a/README.md
+++ b/README.md
@@ -140,10 +140,12 @@ Wildcards are not allowed.
 $ yaymlq set '.services.web.image' nginx:1.28 docker-compose.yml
 $ yaymlq set -i '.spec.replicas' 5 deployment.yaml      # rewrite the file
 $ cat cfg.yaml | yaymlq set --string '.build' 007       # keep "007" a string
+$ yaymlq set '.services.web.labels' '{team: infra}' docker-compose.yml
 ```
 
-`<value>` is parsed as YAML (`8080` → int, `true` → bool); `-s/--string` forces
-a string. `-i/--in-place` rewrites the file instead of printing — atomically
+`<value>` is parsed as YAML: a scalar (`8080` → int, `true` → bool), or a
+collection (`{a: 1}`, `[80, 443]`). `-s/--string` takes the whole argument
+verbatim as a string. `-i/--in-place` rewrites the file instead of printing — atomically
 (temp file + rename), so a crash can't leave a truncated file, and the target's
 mode is preserved. A symlinked path is replaced rather than written through.
 

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -24,8 +24,9 @@ func newSetCommand() *cobra.Command {
 		Short: "Set the value at a path, preserving comments and formatting",
 		Long: "Set writes a new value at the given path and prints the whole document.\n" +
 			"Missing intermediate mapping keys are created. Wildcards are not allowed.\n" +
-			"The value is parsed as YAML (so 8080 is an int, true a bool); use --string\n" +
-			"to keep it a string. With --in-place the file is rewritten instead of printed.",
+			"The value is parsed as YAML — a scalar (8080, true) or a collection\n" +
+			"({a: 1}, [1, 2]); use --string to take it verbatim. With --in-place the\n" +
+			"file is rewritten instead of printed.",
 		Example: "  yaymlq set '.services.web.image' nginx:1.28 compose.yml\n" +
 			"  yaymlq set --string '.metadata.annotations.\"team\"' platform k8s.yaml\n" +
 			"  cat cfg.yaml | yaymlq set .debug true",

--- a/cmd/set_test.go
+++ b/cmd/set_test.go
@@ -112,6 +112,26 @@ func TestSetString(t *testing.T) {
 	}
 }
 
+func TestSetCollectionValue(t *testing.T) {
+	got, err := execute(t, "svc:\n  image: x\n", "set", ".svc.labels", "{team: infra, tier: 1}")
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(got, "team: infra") || !strings.Contains(got, "tier: 1") {
+		t.Fatalf("got:\n%s", got)
+	}
+}
+
+func TestSetCollectionValueAsStringIsLiteral(t *testing.T) {
+	got, err := execute(t, "a: 1\n", "set", "-s", ".a", "{x: 1}")
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if strings.TrimSpace(got) != `a: '{x: 1}'` {
+		t.Fatalf("got %q", got)
+	}
+}
+
 func TestSetWildcardRejected(t *testing.T) {
 	if _, err := execute(t, "a: {b: 1}\n", "set", ".a.*", "2"); err == nil {
 		t.Fatal("expected wildcard to be rejected by set")

--- a/internal/ymledit/ymledit.go
+++ b/internal/ymledit/ymledit.go
@@ -152,8 +152,10 @@ func Delete(doc *yaml.Node, segs []path.Segment) error {
 	return nil
 }
 
-// ParseValue decodes a scalar/flow value string into a node suitable for Set.
-// When asString is true the value keeps the !!str tag regardless of content.
+// ParseValue decodes a value string into a node suitable for Set. The string is
+// parsed as YAML, so it may be a scalar ("8080", "true", "nginx:1.27"), a flow
+// or block collection ("{a: 1}", "[1, 2]", "k:\n  v: 1"), or empty (-> null).
+// When asString is true the value is taken verbatim as a !!str scalar.
 func ParseValue(s string, asString bool) (*yaml.Node, error) {
 	if asString {
 		return &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: s}, nil

--- a/internal/ymledit/ymledit_test.go
+++ b/internal/ymledit/ymledit_test.go
@@ -126,6 +126,43 @@ func TestParseValue(t *testing.T) {
 	}
 }
 
+func TestSetStructuredValue(t *testing.T) {
+	got := apply(t, "a:\n  b: 1\nc: keep\n", ".a", "{x: 1, y: [2, 3]}", false)
+	if !strings.Contains(got, "x: 1") || !strings.Contains(got, "y: [2, 3]") {
+		t.Fatalf("collection value not applied:\n%s", got)
+	}
+	if !strings.Contains(got, "c: keep") {
+		t.Fatalf("sibling key lost:\n%s", got)
+	}
+	if strings.Contains(got, "b: 1") {
+		t.Fatalf("old subtree not replaced:\n%s", got)
+	}
+}
+
+func TestParseValueKinds(t *testing.T) {
+	tests := []struct {
+		in       string
+		asString bool
+		want     yaml.Kind
+	}{
+		{"8080", false, yaml.ScalarNode},
+		{"{a: 1}", false, yaml.MappingNode},
+		{"[1, 2]", false, yaml.SequenceNode},
+		{"k:\n  v: 1", false, yaml.MappingNode},
+		{"{a: 1}", true, yaml.ScalarNode}, // -s wins
+		{"", false, yaml.ScalarNode},      // -> null
+	}
+	for _, tc := range tests {
+		n, err := ymledit.ParseValue(tc.in, tc.asString)
+		if err != nil {
+			t.Fatalf("ParseValue(%q): %v", tc.in, err)
+		}
+		if n.Kind != tc.want {
+			t.Errorf("ParseValue(%q, %v) kind = %v, want %v", tc.in, tc.asString, n.Kind, tc.want)
+		}
+	}
+}
+
 func TestSetErrorMessagesNameTheKind(t *testing.T) {
 	var doc yaml.Node
 	_ = yaml.Unmarshal([]byte("scalar: hi\nlist: [1, 2]\nmap: {x: 1}\n"), &doc)


### PR DESCRIPTION
While looking at "add structured values to `set`" I found it already works —
`ParseValue` parses `<value>` as YAML and returns whatever node kind results:

```console
$ yaymlq set '.services.web.labels' '{team: infra, tier: 1}' compose.yml
$ yaymlq set '.services.web.ports'  '[80, 443]'              compose.yml
$ yaymlq set -s '.build' '{x: 1}'    # -s → literal string '{x: 1}'
```

It was just undocumented and only covered incidentally. This PR:

- Adds `TestParseValueKinds` (scalar / mapping / sequence / block / `-s` wins /
  empty→null) and `TestSetStructuredValue` in `internal/ymledit`, plus
  `TestSetCollectionValue` / `TestSetCollectionValueAsStringIsLiteral` in `cmd`.
- Documents it in the README `set` section, `set --help`, and the `ParseValue`
  doc comment.

No production code change. `make lint` clean, `go test -race ./...`, coverage steady.

🤖 Generated with [Claude Code](https://claude.com/claude-code)