### PR TITLE
docs: cut CHANGELOG 0.3.0 section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-09-01
+
 ### Added
 
 - `yaymlq keys <path> [file]` — a mapping's keys (sorted) or a list's indices.
@@ -54,6 +56,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   order, and formatting. `-i/--in-place` writes atomically (temp file + rename,
   symlink-safe, mode-preserving); `-s/--string` forces a string value.
 
-[Unreleased]: https://github.com/reticule-poirot/yaymlq/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/reticule-poirot/yaymlq/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/reticule-poirot/yaymlq/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/reticule-poirot/yaymlq/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/reticule-poirot/yaymlq/releases/tag/v0.1.0


### PR DESCRIPTION
Roll `[Unreleased]` into `## [0.3.0]`:

- **Added**: `keys`, `len`, `type` verbs (#9)
- **Changed**: `set` collection values documented/tested (#10); `path.Parse` rejects non-UTF-8 (#8)

After merge: tag `v0.3.0` on the merge commit, push, publish the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)