### PR TITLE
feat: add `yaymlq append` to add elements to a list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `yaymlq append <path> <value> [file]` — add `<value>` as the last element of
+  the list at `<path>`. Shares `set`'s `-i/--in-place`, `-s/--string`, `--doc`,
+  and `--max-bytes` flags and its atomic write path. The path must already
+  resolve to a list; wildcards are rejected.
+
 ## [0.3.0] - 2026-09-01
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,18 +22,20 @@ readable, and well-tested rather than feature-complete.
 ## Layout
 
 - `main.go` — entrypoint, calls `cmd.Execute()` (returns the process exit code)
-- `cmd/` — cobra commands: root/get in `root.go`, `set` in `set.go`, `delete`
-  in `delete.go`, the read-only `keys`/`len`/`type` verbs in `inspect.go`
-  (`newInspectCommand` factory); shared edit plumbing (`edit.go`: `applyEdit`
-  read→mutate→write pipeline, `writeFileAtomic`, `decodeNodes`); output
-  rendering (`render.go`), input handling (`input.go`: `--max-bytes` cap +
-  early-stop stream decoding), exit-code handling (`execute.go`, `silentExit`).
+- `cmd/` — cobra commands: root/get in `root.go`, `set` in `set.go`, `append`
+  in `append.go` (both via `runValueEdit` / `bindValueEditFlags` in `set.go`),
+  `delete` in `delete.go`, the read-only `keys`/`len`/`type` verbs in
+  `inspect.go` (`newInspectCommand` factory); shared edit plumbing (`edit.go`:
+  `applyEdit` read→mutate→write pipeline, `writeFileAtomic`, `decodeNodes`);
+  output rendering (`render.go`), input handling (`input.go`: `--max-bytes` cap
+  + early-stop stream decoding), exit-code handling (`execute.go`, `silentExit`).
 - `internal/path/` — path expression parser, `Parse` -> `[]Segment` (keys,
   indices, wildcards). Shared by query and ymledit. Fuzzed.
 - `internal/query/` — read-only resolver: `Run(doc any, expr) ([]any, error)`,
   wildcards fan out. Fuzzed.
-- `internal/ymledit/` — `Set` and `Delete` edit a `*yaml.Node` tree preserving
-  comments and key order; back `yaymlq set` / `yaymlq delete`. Fuzzed.
+- `internal/ymledit/` — `Set`, `Append`, and `Delete` edit a `*yaml.Node` tree
+  preserving comments and key order; back the `set` / `append` / `delete`
+  commands. Fuzzed (`FuzzSet`, `FuzzAppend`, `FuzzDelete`).
 
 ## Conventions
 

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ fuzz:
 	go test ./internal/path    -run '^$$' -fuzz FuzzParse  -fuzztime $(FUZZTIME)
 	go test ./internal/query   -run '^$$' -fuzz FuzzRun    -fuzztime $(FUZZTIME)
 	go test ./internal/ymledit -run '^$$' -fuzz FuzzSet    -fuzztime $(FUZZTIME)
+	go test ./internal/ymledit -run '^$$' -fuzz FuzzAppend -fuzztime $(FUZZTIME)
 	go test ./internal/ymledit -run '^$$' -fuzz FuzzDelete -fuzztime $(FUZZTIME)
 
 GOLANGCI_VERSION ?= v2.1.6

--- a/README.md
+++ b/README.md
@@ -149,6 +149,22 @@ verbatim as a string. `-i/--in-place` rewrites the file instead of printing — 
 (temp file + rename), so a crash can't leave a truncated file, and the target's
 mode is preserved. A symlinked path is replaced rather than written through.
 
+## Appending: `yaymlq append`
+
+```
+yaymlq append [flags] <path> <value> [file]
+```
+
+Adds `<value>` as the last element of the list at `<path>`. The path must
+already resolve to a list. Same `<value>` parsing and same flags as `set`
+(`-s/--string`, `-i/--in-place`, `--doc`, `--max-bytes`).
+
+```console
+$ yaymlq append '.services.web.ports' '"9090:9090"' docker-compose.yml
+$ yaymlq append -i '.spec.template.spec.containers' '{name: proxy, image: envoy}' k8s.yaml
+$ cat cfg.yaml | yaymlq append .tags newtag
+```
+
 ## Deleting: `yaymlq delete`
 
 ```
@@ -199,7 +215,7 @@ go test ./cmd -run TestGolden -update
 
 ```
 main.go                 entrypoint
-cmd/                     cobra commands (get, set, delete, keys/len/type), I/O, rendering
+cmd/                     cobra commands (get, set, append, delete, keys/len/type), I/O
 internal/path/           path expression parser (shared)
 internal/query/          read-only resolver: path -> value(s)
 internal/ymledit/        comment-preserving writer for `set` and `delete`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,8 +17,8 @@ released and the advisory published with credit unless you prefer otherwise.
 ## Threat model
 
 `yaymlq` is a local command-line tool. It reads YAML from a file or stdin that
-the invoking user chose, and (with `set` / `delete`) writes back to a path the
-user named. It makes no network connections and runs no subprocesses.
+the invoking user chose, and (with `set` / `append` / `delete`) writes back
+to a path the user named. It makes no network connections and runs no subprocesses.
 
 Hardening already in place:
 
@@ -28,7 +28,7 @@ Hardening already in place:
   requested document.
 - YAML alias-expansion bombs are rejected by `gopkg.in/yaml.v3` (≥ v3.0.1);
   a regression test guards this.
-- `set --in-place` / `delete --in-place` write atomically (temp file +
+- `set` / `append` / `delete` with `--in-place` write atomically (temp file +
   `rename`), never leaving a truncated file, and replace a symlinked path
   rather than writing through it.
 

--- a/cmd/append.go
+++ b/cmd/append.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"github.com/reticule-poirot/yaymlq/internal/ymledit"
+	"github.com/spf13/cobra"
+)
+
+func newAppendCommand() *cobra.Command {
+	opts := &valueEditOptions{editOpts: editOpts{maxBytes: defaultMaxBytes}}
+
+	cmd := &cobra.Command{
+		Use:   "append <path> <value> [file]",
+		Short: "Append a value to the list at a path, preserving formatting",
+		Long: "Append adds <value> as the last element of the list at <path> and prints\n" +
+			"the whole document. The path must already resolve to a list; wildcards are\n" +
+			"not allowed. <value> is parsed as YAML (a scalar or a collection); use\n" +
+			"--string to take it verbatim. With --in-place the file is rewritten.",
+		Example: "  yaymlq append '.services.web.ports' '\"9090:9090\"' compose.yml\n" +
+			"  yaymlq append -i '.spec.template.spec.containers' '{name: proxy, image: envoy}' k8s.yaml\n" +
+			"  cat cfg.yaml | yaymlq append .tags newtag",
+		Args:         cobra.RangeArgs(2, 3),
+		SilenceUsage: true,
+		RunE: func(c *cobra.Command, args []string) error {
+			return runValueEdit(c, opts, args, ymledit.Append)
+		},
+	}
+	bindValueEditFlags(cmd, opts)
+	return cmd
+}

--- a/cmd/append_test.go
+++ b/cmd/append_test.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAppendToStdout(t *testing.T) {
+	in := "ports:\n  - 80 # http\n  - 443\nname: web\n"
+	got, err := execute(t, in, "append", ".ports", "9090")
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(got, "- 9090") || !strings.Contains(got, "# http") || !strings.Contains(got, "name: web") {
+		t.Fatalf("got:\n%s", got)
+	}
+}
+
+func TestAppendInPlace(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "c.yaml")
+	if err := os.WriteFile(f, []byte("tags:\n  - a\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := execute(t, "", "append", "-i", ".tags", "b", f); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	out, err := os.ReadFile(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(out)) != "tags:\n  - a\n  - b" {
+		t.Fatalf("file after edit:\n%s", out)
+	}
+}
+
+func TestAppendString(t *testing.T) {
+	got, err := execute(t, "l: [1, 2]\n", "append", "-s", ".l", "007")
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if strings.TrimSpace(got) != `l: [1, 2, "007"]` {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestAppendSecondDoc(t *testing.T) {
+	in := "a: [1]\n---\nb: [2]\n"
+	got, err := execute(t, in, "append", "--doc", "1", ".b", "3")
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !strings.Contains(got, "b: [2, 3]") || !strings.Contains(got, "a: [1]") {
+		t.Fatalf("got:\n%s", got)
+	}
+}
+
+func TestAppendErrorPaths(t *testing.T) {
+	tests := []struct {
+		name  string
+		stdin string
+		args  []string
+	}{
+		{"no documents", "", []string{"append", ".a", "1"}},
+		{"append into mapping", "a: {b: 1}\n", []string{"append", ".a", "1"}},
+		{"append into scalar", "a: 1\n", []string{"append", ".a", "1"}},
+		{"missing path", "a: [1]\n", []string{"append", ".nope", "1"}},
+		{"wildcard", "a: [1]\n", []string{"append", ".a.*", "1"}},
+		{"in-place without file", "a: [1]\n", []string{"append", "-i", ".a", "1"}},
+		{"file not found", "", []string{"append", ".a", "1", "/no/such/file.yaml"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := execute(t, tc.stdin, tc.args...); err == nil {
+				t.Fatalf("expected error for %v", tc.args)
+			}
+		})
+	}
+}

--- a/cmd/golden_test.go
+++ b/cmd/golden_test.go
@@ -27,6 +27,7 @@ func TestGolden(t *testing.T) {
 		{"set-new-key", []string{"set", ".spec.strategy.type", "RollingUpdate", "../testdata/k8s.yaml"}},
 		{"delete-key", []string{"delete", ".services.web.environment", "../testdata/compose.yml"}},
 		{"delete-list-elem", []string{"delete", ".spec.template.spec.containers[1]", "../testdata/k8s.yaml"}},
+		{"append-port", []string{"append", ".services.web.ports", "8080:8080", "../testdata/compose.yml"}},
 		{"keys-map", []string{"keys", ".services.web", "../testdata/compose.yml"}},
 		{"len-list", []string{"len", ".spec.template.spec.containers", "../testdata/k8s.yaml"}},
 		{"type-nested", []string{"type", ".spec.template.spec.containers[0].ports", "../testdata/k8s.yaml"}},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,6 +69,7 @@ Path syntax:
 	f.BoolVarP(&opts.exitStatus, "exit-status", "e", false, "exit 1 (no output) when the path has no match")
 
 	cmd.AddCommand(newSetCommand())
+	cmd.AddCommand(newAppendCommand())
 	cmd.AddCommand(newDeleteCommand())
 	cmd.AddCommand(newInspectCommand(
 		"keys <path> [file]",

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -11,13 +11,15 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-type setOptions struct {
+// valueEditOptions is shared by the subcommands that take a <value> argument
+// (set, append).
+type valueEditOptions struct {
 	editOpts
 	asString bool
 }
 
 func newSetCommand() *cobra.Command {
-	opts := &setOptions{editOpts: editOpts{maxBytes: defaultMaxBytes}}
+	opts := &valueEditOptions{editOpts: editOpts{maxBytes: defaultMaxBytes}}
 
 	cmd := &cobra.Command{
 		Use:   "set <path> <value> [file]",
@@ -33,20 +35,24 @@ func newSetCommand() *cobra.Command {
 		Args:         cobra.RangeArgs(2, 3),
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
-			return runSet(c, opts, args)
+			return runValueEdit(c, opts, args, ymledit.Set)
 		},
 	}
+	bindValueEditFlags(cmd, opts)
+	return cmd
+}
 
+func bindValueEditFlags(cmd *cobra.Command, opts *valueEditOptions) {
 	f := cmd.Flags()
 	f.BoolVarP(&opts.inPlace, "in-place", "i", false, "rewrite the file instead of printing to stdout")
 	f.BoolVarP(&opts.asString, "string", "s", false, "treat <value> as a string, not parsed YAML")
 	f.IntVar(&opts.docIdx, "doc", 0, "index of the document to edit in a multi-doc stream")
 	f.Int64Var(&opts.maxBytes, "max-bytes", opts.maxBytes, "max input bytes to buffer; 0 = unlimited")
-
-	return cmd
 }
 
-func runSet(c *cobra.Command, opts *setOptions, args []string) error {
+// runValueEdit is the common flow for set and append: parse the path and value,
+// open the input, then hand the selected document to apply.
+func runValueEdit(c *cobra.Command, opts *valueEditOptions, args []string, apply func(*yaml.Node, []path.Segment, *yaml.Node) error) error {
 	expr, rawValue := args[0], args[1]
 	filename := ""
 	if len(args) == 3 && args[2] != "-" {
@@ -77,6 +83,6 @@ func runSet(c *cobra.Command, opts *setOptions, args []string) error {
 	}
 
 	return applyEdit(c, src, closeSrc, filename, opts.editOpts, func(docs []*yaml.Node, i int) error {
-		return ymledit.Set(docs[i], segs, value)
+		return apply(docs[i], segs, value)
 	})
 }

--- a/internal/ymledit/fuzz_test.go
+++ b/internal/ymledit/fuzz_test.go
@@ -69,6 +69,42 @@ func FuzzSet(f *testing.F) {
 	})
 }
 
+// FuzzAppend checks the same for list appends.
+func FuzzAppend(f *testing.F) {
+	seeds := []struct{ expr, val string }{
+		{".meta.ports", "9090"},
+		{".meta.ports", "{a: 1}"},
+		{".list", "{id: 3}"},
+		{".list[0]", "x"},
+		{".name", "x"},
+		{".meta", "x"},
+		{".missing", "x"},
+		{"", "x"},
+		{".meta.*", "x"},
+	}
+	for _, s := range seeds {
+		f.Add(s.expr, s.val)
+	}
+
+	f.Fuzz(func(t *testing.T, expr, val string) {
+		segs, err := path.Parse(expr)
+		if err != nil {
+			return
+		}
+		value, err := ymledit.ParseValue(val, false)
+		if err != nil {
+			return
+		}
+		doc := freshSeed(t)
+		if err := ymledit.Append(doc, segs, value); err != nil {
+			return
+		}
+		if _, err := yaml.Marshal(doc); err != nil {
+			t.Fatalf("Append(%q, %q) produced a tree that will not encode: %v", expr, val, err)
+		}
+	})
+}
+
 // FuzzDelete checks the same for removals.
 func FuzzDelete(f *testing.F) {
 	for _, expr := range []string{

--- a/internal/ymledit/ymledit.go
+++ b/internal/ymledit/ymledit.go
@@ -152,6 +152,64 @@ func Delete(doc *yaml.Node, segs []path.Segment) error {
 	return nil
 }
 
+// Append walks doc along segs to the node the path resolves to and adds value
+// as its last element.
+//
+// The target must already exist and be a sequence — appending into a mapping or
+// scalar, or through a missing key, is an error. Wildcards and the empty path
+// are rejected. Comments on the existing elements are untouched.
+func Append(doc *yaml.Node, segs []path.Segment, value *yaml.Node) error {
+	if len(segs) == 0 {
+		return fmt.Errorf("%w: refusing to append to the whole document", ErrUnsupported)
+	}
+
+	cur := doc
+	if doc.Kind == yaml.DocumentNode {
+		if len(doc.Content) == 0 {
+			return errors.New("the document is empty")
+		}
+		cur = doc.Content[0]
+	}
+
+	for i, seg := range segs {
+		at := path.Format(segs[:i+1])
+
+		switch {
+		case seg.IsWildcard:
+			return fmt.Errorf("%w: %s: wildcards cannot be used with append", ErrUnsupported, at)
+
+		case seg.IsIndex:
+			if cur.Kind != yaml.SequenceNode {
+				return fmt.Errorf("%s: expected a list, got %s", at, kindName(cur.Kind))
+			}
+			idx := seg.Index
+			if idx < 0 {
+				idx += len(cur.Content)
+			}
+			if idx < 0 || idx >= len(cur.Content) {
+				return fmt.Errorf("%s: index %d out of range (len %d)", at, seg.Index, len(cur.Content))
+			}
+			cur = cur.Content[idx]
+
+		default: // map key
+			if cur.Kind != yaml.MappingNode {
+				return fmt.Errorf("%s: expected a mapping, got %s", at, kindName(cur.Kind))
+			}
+			vi := findValueIndex(cur, seg.Key)
+			if vi < 0 {
+				return fmt.Errorf("%s: no such key", at)
+			}
+			cur = cur.Content[vi]
+		}
+	}
+
+	if cur.Kind != yaml.SequenceNode {
+		return fmt.Errorf("%s: expected a list to append to, got %s", path.Format(segs), kindName(cur.Kind))
+	}
+	cur.Content = append(cur.Content, value)
+	return nil
+}
+
 // ParseValue decodes a value string into a node suitable for Set. The string is
 // parsed as YAML, so it may be a scalar ("8080", "true", "nginx:1.27"), a flow
 // or block collection ("{a: 1}", "[1, 2]", "k:\n  v: 1"), or empty (-> null).

--- a/internal/ymledit/ymledit_test.go
+++ b/internal/ymledit/ymledit_test.go
@@ -293,3 +293,86 @@ func TestDeleteWildcardIsUnsupported(t *testing.T) {
 		t.Fatalf("want ErrUnsupported, got %v", err)
 	}
 }
+
+func appendTo(t *testing.T, src, expr, value string) string {
+	t.Helper()
+	var doc yaml.Node
+	if err := yaml.Unmarshal([]byte(src), &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	segs, err := path.Parse(expr)
+	if err != nil {
+		t.Fatalf("parse path: %v", err)
+	}
+	vn, err := ymledit.ParseValue(value, false)
+	if err != nil {
+		t.Fatalf("parse value: %v", err)
+	}
+	if err := ymledit.Append(&doc, segs, vn); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	var buf bytes.Buffer
+	enc := yaml.NewEncoder(&buf)
+	enc.SetIndent(2)
+	if err := enc.Encode(&doc); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	_ = enc.Close()
+	return buf.String()
+}
+
+func TestAppendScalar(t *testing.T) {
+	got := appendTo(t, "tags:\n  - a\n  - b\nname: x\n", ".tags", "c")
+	if !strings.Contains(got, "- c") || !strings.Contains(got, "name: x") {
+		t.Fatalf("got:\n%s", got)
+	}
+	if strings.Index(got, "- c") < strings.Index(got, "- b") {
+		t.Fatalf("appended element is not last:\n%s", got)
+	}
+}
+
+func TestAppendCollection(t *testing.T) {
+	got := appendTo(t, "items:\n  - {id: 1}\n", ".items", "{id: 2, on: true}")
+	if !strings.Contains(got, "id: 2") || !strings.Contains(got, "on: true") {
+		t.Fatalf("got:\n%s", got)
+	}
+}
+
+func TestAppendNestedViaIndex(t *testing.T) {
+	got := appendTo(t, "m:\n  - [1, 2]\n  - [3, 4]\n", ".m[0]", "9")
+	if !strings.Contains(got, "[1, 2, 9]") {
+		t.Fatalf("got:\n%s", got)
+	}
+}
+
+func TestAppendKeepsComments(t *testing.T) {
+	got := appendTo(t, "tags:\n  - a # first\n  - b # second\n", ".tags", "c")
+	if !strings.Contains(got, "# first") || !strings.Contains(got, "# second") {
+		t.Fatalf("existing comments lost:\n%s", got)
+	}
+}
+
+func TestAppendErrors(t *testing.T) {
+	src := "list: [1, 2]\nmap: {a: 1}\nscalar: hi\n"
+	cases := []struct {
+		name, expr, want string
+	}{
+		{"into mapping", ".map", "expected a list to append to, got mapping"},
+		{"into scalar", ".scalar", "expected a list to append to, got scalar"},
+		{"missing key", ".nope", "no such key"},
+		{"index out of range", ".list[9]", "index 9 out of range"},
+		{"wildcard", ".list.*", "wildcards cannot be used with append"},
+		{"whole document", "", "whole document"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var doc yaml.Node
+			_ = yaml.Unmarshal([]byte(src), &doc)
+			segs, _ := path.Parse(tc.expr)
+			err := ymledit.Append(&doc, segs, &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: "x"})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Append(%q) err = %v, want to contain %q", tc.expr, err, tc.want)
+			}
+		})
+	}
+}

--- a/testdata/golden/append-port.golden
+++ b/testdata/golden/append-port.golden
@@ -1,0 +1,16 @@
+version: "3.9"
+services:
+  web:
+    image: nginx:1.27
+    ports:
+      - "80:80"
+      - "443:443"
+      - 8080:8080
+    environment:
+      APP_ENV: production
+  db:
+    image: postgres:16
+    ports:
+      - "5432:5432"
+volumes:
+  pgdata: {}


### PR DESCRIPTION
Closes the last CRUD gap: you could create / read / replace / delete a list and
its elements-by-index, but not **add** one.

```console
$ yaymlq append '.services.web.ports' '"9090:9090"' compose.yml
$ yaymlq append -i '.spec.template.spec.containers' '{name: proxy, image: envoy}' k8s.yaml
$ cat cfg.yaml | yaymlq append .tags newtag
```

## Design

- `ymledit.Append(doc, segs, value)` navigates every segment (like `Delete`) to
  the node the path points at; that node must be a **sequence**, then `value` is
  appended. The list must already exist — appending through a missing key or
  into a mapping/scalar is an error. Wildcards and the empty path rejected.
- `<value>` parsed as YAML exactly like `set` (scalar or collection; `-s` verbatim).
- `set` and `append` now share `runValueEdit` / `bindValueEditFlags` /
  `valueEditOptions` (renamed from `setOptions`). `append` inherits `set`'s
  `-i` / `-s` / `--doc` / `--max-bytes` and the atomic write path.
- `FuzzAppend` added; `make fuzz` + CI now run 5 targets.

## Checks

11 `ymledit` tests + 6 `cmd` tests + 1 golden. `make lint` (0 issues),
`go test -race ./...`, `make fuzz` (5 targets green), coverage 90.1%, tidy clean.

## Security review (write path)

`Append` is in-memory tree navigation with every index bounds-checked and
wildcards/empty-path rejected before any mutation; an alias or non-sequence
target errors rather than being followed/mutated. Reuses `runValueEdit` →
`applyEdit`: same `--max-bytes` cap, same alias-bomb-protected decoder, same
close-input-before-write ordering, same unchanged `writeFileAtomic`. `append -i`
has exactly `set -i`'s capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)