### PR TITLE
docs: cut CHANGELOG 0.4.0 section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-09-01
+
 ### Added
 
 - `yaymlq append <path> <value> [file]` — add `<value>` as the last element of
@@ -63,7 +65,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   order, and formatting. `-i/--in-place` writes atomically (temp file + rename,
   symlink-safe, mode-preserving); `-s/--string` forces a string value.
 
-[Unreleased]: https://github.com/reticule-poirot/yaymlq/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/reticule-poirot/yaymlq/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/reticule-poirot/yaymlq/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/reticule-poirot/yaymlq/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/reticule-poirot/yaymlq/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/reticule-poirot/yaymlq/releases/tag/v0.1.0


### PR DESCRIPTION
Roll `[Unreleased]` into `## [0.4.0]` — adds `yaymlq append` (#12).

After merge: tag `v0.4.0` on the merge commit, push, publish the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)