### PR TITLE
feat: preserve source blank lines through set / append / delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- `set` / `append` / `delete` now keep the blank lines from the source
+  document. `gopkg.in/yaml.v3` discards them on decode; yaymlq re-inserts a
+  blank line before any node that had one above it in the input (a run of blank
+  lines collapses to one). Comment text, key order, and quoting were already
+  preserved; comment-to-value spacing is still normalized to a single space.
+
 ## [0.4.0] - 2026-09-01
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,9 @@ readable, and well-tested rather than feature-complete.
   in `append.go` (both via `runValueEdit` / `bindValueEditFlags` in `set.go`),
   `delete` in `delete.go`, the read-only `keys`/`len`/`type` verbs in
   `inspect.go` (`newInspectCommand` factory); shared edit plumbing (`edit.go`:
-  `applyEdit` read→mutate→write pipeline, `writeFileAtomic`, `decodeNodes`);
+  `applyEdit` read→mutate→write pipeline, `writeFileAtomic`, `decodeNodes`;
+  `blanklines.go`: `preserveBlankLines` re-inserts source blank lines yaml.v3
+  drops, `tidyBlankLines` cleans the encoder's indented blanks);
   output rendering (`render.go`), input handling (`input.go`: `--max-bytes` cap
   + early-stop stream decoding), exit-code handling (`execute.go`, `silentExit`).
 - `internal/path/` — path expression parser, `Parse` -> `[]Segment` (keys,
@@ -35,7 +37,8 @@ readable, and well-tested rather than feature-complete.
   wildcards fan out. Fuzzed.
 - `internal/ymledit/` — `Set`, `Append`, and `Delete` edit a `*yaml.Node` tree
   preserving comments and key order; back the `set` / `append` / `delete`
-  commands. Fuzzed (`FuzzSet`, `FuzzAppend`, `FuzzDelete`).
+  commands (blank-line preservation lives in `cmd/blanklines.go`, not here).
+  Fuzzed (`FuzzSet`, `FuzzAppend`, `FuzzDelete`).
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -133,8 +133,13 @@ yaymlq set [flags] <path> <value> [file]
 ```
 
 Sets the value at `<path>` and prints the whole document; comments, key order,
-and formatting are preserved. Missing intermediate mapping keys are created.
-Wildcards are not allowed.
+quoting, and blank lines are preserved. Missing intermediate mapping keys are
+created. Wildcards are not allowed.
+
+> A run of blank lines collapses to one, and the space between a value and its
+> trailing `# comment` is normalized to one — limitations of the underlying
+> `gopkg.in/yaml.v3` re-serializer. `set`, `append`, and `delete` all behave
+> this way.
 
 ```console
 $ yaymlq set '.services.web.image' nginx:1.28 docker-compose.yml

--- a/cmd/blanklines.go
+++ b/cmd/blanklines.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// gopkg.in/yaml.v3 records the source line of every node but throws away blank
+// lines when it decodes, so a round-trip through set / append / delete collapses
+// the vertical spacing of a hand-formatted document. The encoder will, however,
+// emit a blank line before a node whose HeadComment begins with a newline.
+//
+// preserveBlankLines bridges the two: it runs on the freshly decoded tree
+// (before any mutation, while Line numbers still line up with source) and, for
+// every node that had a blank line above it in source, prefixes that node's
+// HeadComment with "\n". A run of blank lines collapses to one.
+func preserveBlankLines(doc *yaml.Node, source []byte) {
+	blank := blankLines(source)
+	if len(blank) == 0 {
+		return
+	}
+	markBlankLines(doc, blank)
+}
+
+// blankLines returns the set of 1-indexed source line numbers that are empty or
+// whitespace-only — the same numbering yaml.Node.Line uses.
+func blankLines(source []byte) map[int]bool {
+	out := make(map[int]bool)
+	for i, line := range strings.Split(string(source), "\n") {
+		if strings.TrimSpace(line) == "" {
+			out[i+1] = true
+		}
+	}
+	return out
+}
+
+func markBlankLines(n *yaml.Node, blank map[int]bool) {
+	switch n.Kind {
+	case yaml.DocumentNode:
+		for _, c := range n.Content {
+			markBlankLines(c, blank)
+		}
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(n.Content); i += 2 {
+			markBlankAbove(n.Content[i], blank)
+			markBlankLines(n.Content[i+1], blank)
+		}
+	case yaml.SequenceNode:
+		for _, c := range n.Content {
+			markBlankAbove(c, blank)
+			markBlankLines(c, blank)
+		}
+	}
+}
+
+// markBlankAbove prefixes n.HeadComment with a newline when the source line
+// directly above n (or above n's head comment block, if it has one) was blank.
+func markBlankAbove(n *yaml.Node, blank map[int]bool) {
+	above := n.Line - 1
+	if n.HeadComment != "" {
+		above -= strings.Count(n.HeadComment, "\n") + 1
+	}
+	if above >= 1 && blank[above] && !strings.HasPrefix(n.HeadComment, "\n") {
+		n.HeadComment = "\n" + n.HeadComment
+	}
+}
+
+// tidyBlankLines rewrites lines that are only spaces or tabs as empty lines.
+// yaml.v3 indents the blank lines it emits for nested nodes; it never emits a
+// semantically significant whitespace-only line (a block scalar that would
+// contain one is written as a quoted string instead), so this only touches
+// spacing.
+func tidyBlankLines(b []byte) []byte {
+	lines := bytes.Split(b, []byte("\n"))
+	for i, line := range lines {
+		if len(line) > 0 && len(bytes.TrimLeft(line, " \t")) == 0 {
+			lines[i] = nil
+		}
+	}
+	return bytes.Join(lines, []byte("\n"))
+}

--- a/cmd/blanklines_test.go
+++ b/cmd/blanklines_test.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestEditPreservesBlankLines(t *testing.T) {
+	in := "version: \"3.9\"\n\nservices:\n  web:\n    image: nginx:1.27\n\n    ports:\n      - \"80:80\"\n\nvolumes:\n  data: {}\n"
+
+	for _, tc := range []struct {
+		name string
+		args []string
+	}{
+		{"set", []string{"set", ".services.web.image", "nginx:1.28"}},
+		{"append", []string{"append", ".services.web.ports", "9090"}},
+		{"delete", []string{"delete", ".volumes.data"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := execute(t, in, tc.args...)
+			if err != nil {
+				t.Fatalf("execute: %v", err)
+			}
+			if strings.Count(got, "\n\n") != 3 {
+				t.Fatalf("want 3 blank lines preserved, got:\n%s", got)
+			}
+		})
+	}
+}
+
+func TestEditBlankLinesHaveNoTrailingWhitespace(t *testing.T) {
+	// The blank line between image and ports sits at indent 4; the encoder
+	// pads it, tidyBlankLines must strip that back to an empty line.
+	in := "a:\n  b: 1\n\n  c: 2\n"
+	got, err := execute(t, in, "set", ".a.b", "9")
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	for _, line := range strings.Split(got, "\n") {
+		if line != "" && strings.TrimSpace(line) == "" {
+			t.Fatalf("blank line has trailing whitespace %q in:\n%s", line, got)
+		}
+	}
+}
+
+func TestEditRunsOfBlankLinesCollapse(t *testing.T) {
+	got, err := execute(t, "a: 1\n\n\n\nb: 2\n", "set", ".a", "9")
+	if err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if want := "a: 9\n\nb: 2\n"; got != want {
+		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestPreserveBlankLinesIsIdempotent(t *testing.T) {
+	src := []byte("a: 1\n\nb: 2\n")
+	var doc yaml.Node
+	if err := yaml.Unmarshal(src, &doc); err != nil {
+		t.Fatal(err)
+	}
+	preserveBlankLines(&doc, src)
+	preserveBlankLines(&doc, src)
+	if h := doc.Content[0].Content[2].HeadComment; h != "\n" {
+		t.Fatalf("HeadComment = %q, want one leading newline", h)
+	}
+}

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -41,6 +41,9 @@ func applyEdit(c *cobra.Command, src io.Reader, closeSrc func() error, filename 
 	if len(docs) == 0 {
 		return fmt.Errorf("no YAML documents on input")
 	}
+	for _, d := range docs {
+		preserveBlankLines(d, data)
+	}
 	if opts.docIdx < 0 || opts.docIdx >= len(docs) {
 		return fmt.Errorf("document index %d out of range (%d documents)", opts.docIdx, len(docs))
 	}
@@ -60,12 +63,13 @@ func applyEdit(c *cobra.Command, src io.Reader, closeSrc func() error, filename 
 	if err := enc.Close(); err != nil {
 		return err
 	}
+	out := tidyBlankLines(buf.Bytes())
 
 	if opts.inPlace {
-		return writeFileAtomic(filename, buf.Bytes())
+		return writeFileAtomic(filename, out)
 	}
 
-	_, err = c.OutOrStdout().Write(buf.Bytes())
+	_, err = c.OutOrStdout().Write(out)
 	return err
 }
 

--- a/testdata/golden/append-port.golden
+++ b/testdata/golden/append-port.golden
@@ -1,4 +1,5 @@
 version: "3.9"
+
 services:
   web:
     image: nginx:1.27
@@ -12,5 +13,6 @@ services:
     image: postgres:16
     ports:
       - "5432:5432"
+
 volumes:
   pgdata: {}

--- a/testdata/golden/delete-key.golden
+++ b/testdata/golden/delete-key.golden
@@ -1,4 +1,5 @@
 version: "3.9"
+
 services:
   web:
     image: nginx:1.27
@@ -9,5 +10,6 @@ services:
     image: postgres:16
     ports:
       - "5432:5432"
+
 volumes:
   pgdata: {}

--- a/testdata/golden/set-image.golden
+++ b/testdata/golden/set-image.golden
@@ -1,4 +1,5 @@
 version: "3.9"
+
 services:
   web:
     image: nginx:1.28
@@ -11,5 +12,6 @@ services:
     image: postgres:16
     ports:
       - "5432:5432"
+
 volumes:
   pgdata: {}


### PR DESCRIPTION
## What

`set`, `append`, and `delete` now keep the blank lines from the input document.

`gopkg.in/yaml.v3` throws blank lines away on decode, so any edit used to
collapse a hand-formatted file's spacing:

```
version: "3.9"        version: "3.9"
                  →   services:
services:               ...
```

## How

`cmd/blanklines.go`:

- **`preserveBlankLines`** runs on the freshly decoded node tree, before any
  mutation, while each node's `Line` still matches the source. For every node
  that had a blank line directly above it (accounting for a head-comment block),
  it prefixes the node's `HeadComment` with `"\n"`. yaml.v3's encoder emits a
  blank line for that. A run of blank lines collapses to one.
- **`tidyBlankLines`** rewrites the indented blank lines the encoder pads for
  nested nodes back to empty lines. yaml.v3 never emits a semantically
  significant whitespace-only line (a block scalar that would contain one is
  written as a quoted string), so this only touches spacing.

Wired into `applyEdit` — one annotate pass after decode, one tidy pass after
encode. Node `Line` numbers are stream-global, so multi-document input works.

## Not covered

The space between a value and its trailing `# comment` is still normalized to
one by yaml.v3's `LineComment` rendering. Comment text, key order, and quoting
were already preserved.

## Tests

- `cmd/blanklines_test.go` — set/append/delete preserve blanks, no trailing
  whitespace on emitted blanks, runs collapse, `preserveBlankLines` idempotent.
- Goldens regenerated: `compose.yml` has two blank lines, now visible in
  `set-image`, `append-port`, `delete-key`.
- `make ci` + `make fuzz` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)