### PR TITLE
docs: cut CHANGELOG 0.4.1 section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-09-01
+
 ### Changed
 
 - `set` / `append` / `delete` now keep the blank lines from the source
@@ -73,7 +75,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   order, and formatting. `-i/--in-place` writes atomically (temp file + rename,
   symlink-safe, mode-preserving); `-s/--string` forces a string value.
 
-[Unreleased]: https://github.com/reticule-poirot/yaymlq/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/reticule-poirot/yaymlq/compare/v0.4.1...HEAD
+[0.4.1]: https://github.com/reticule-poirot/yaymlq/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/reticule-poirot/yaymlq/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/reticule-poirot/yaymlq/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/reticule-poirot/yaymlq/compare/v0.1.0...v0.2.0


### PR DESCRIPTION
Moves the blank-line-preservation entry (#14) from `[Unreleased]` into
`[0.4.1]` and adds the compare-link. Patch release — behavior refinement to
`set` / `append` / `delete`, no new commands or flags.

Tag + GitHub Release follow once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)